### PR TITLE
Using uint8_t instead of char

### DIFF
--- a/Sources.cmake
+++ b/Sources.cmake
@@ -28,4 +28,5 @@ set (sources
     src/wrap-hwlib.cpp
     src/libc-stub.cpp
     src/main.cpp
+    src/uart_connection.cpp
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@ int main() {
     hwlib::cout << "Initialized transceiver" << hwlib::endl;
 
 
-    /// Initialize UART controller 3. Use a 115200 baudrate to send and receive (used by the uArm Swift Pro to send Gcode commands).
+    ///< Initialize UART controller 3. Use a 115200 baudrate to send and receive (used by the uArm Swift Pro to send Gcode commands).
     UARTConnection conn(115200, UARTController::THREE);
     hwlib::wait_ms(500);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,37 @@
 #include "wrap-hwlib.hpp"
 
+#include "uart_connection.hpp"
+
+
 int main() {
     WDT->WDT_MR = WDT_MR_WDDIS;
 
-    hwlib::wait_ms(1000);
-    hwlib::cout << "Hello world!" << hwlib::endl;
+    namespace target = hwlib::target;
 
-    return 0;
+    hwlib::wait_ms(500);
+
+    hwlib::cout << "Initialized transceiver" << hwlib::endl;
+
+
+    /// Initialize UART controller 3. Use a 115200 baudrate to send and receive (used by the uArm Swift Pro to send Gcode commands).
+    UARTConnection conn(115200, UARTController::THREE);
+    hwlib::wait_ms(500);
+
+    long startMsReceive = hwlib::now_us() / 1000;
+    long startMsSend = hwlib::now_us() / 1000;
+
+    while (true) {
+        if ((hwlib::now_us() / 1000) - startMsSend > 2500) {
+            startMsSend = hwlib::now_us() / 1000;
+            conn << "Hello World!";
+        }
+
+        if (conn.available() > 0 && (hwlib::now_us() / 1000) - startMsReceive > 30) {
+            startMsReceive = hwlib::now_us() / 1000;
+
+            for (unsigned int i = 0; i < conn.available(); i++) {
+                hwlib::cout << conn.receive();
+            }
+        }
+    }
 }

--- a/src/uart_connection.cpp
+++ b/src/uart_connection.cpp
@@ -1,102 +1,111 @@
 #include "uart_connection.hpp"
 
-UARTConnection::UARTConnection(unsigned int baudrate, UARTController controller, bool initializeController) : baudrate(baudrate), controller(controller) {
+UARTConnection::UARTConnection(unsigned int baudrate, UARTController controller, bool initializeController) : baudrate(baudrate), controller(controller), USARTControllerInitialized(false) {
     if (initializeController) {
         begin();
     }
 }
 
 UARTConnection::~UARTConnection() {
-    /// Disable the UART controller on destruction
+    ///> Disable the UART controller on destruction
     disable();
 }
 
 void UARTConnection::begin() {
-    /// Only initialize the UART controller if it hasn't been enabled.
+    ///> Only initialize the UART controller if it hasn't been enabled.
     if (USARTControllerInitialized) {
         return;
     }
 
-    /// Setup the correct USART controller.
+    ///> Setup the correct USART controller.
     if (controller == UARTController::ONE) {
         hardwareUSART = USART0;
 
-        /// Disable PIO control on PA10, PA11 and set up for peripheral A.
+        ///> Disable PIO control on PA10, PA11 and set up for peripheral A.
         PIOA->PIO_PDR = PIO_PA10;
         PIOA->PIO_ABSR &= ~PIO_PA10;
         PIOA->PIO_PDR = PIO_PA11;
         PIOA->PIO_ABSR &= ~PIO_PA11;
 
-        /// Enable the clock to USART0.
+        ///> Enable the clock to USART0.
         PMC->PMC_PCER0 = (0x01 << ID_USART0);
     } else if (controller == UARTController::TWO) {
         hardwareUSART = USART1;
 
-        /// Disable PIO control on PA12, PA13 and set up for peripheral A.
+        ///> Disable PIO control on PA12, PA13 and set up for peripheral A.
         PIOA->PIO_PDR = PIO_PA12;
         PIOA->PIO_ABSR &= ~PIO_PA12;
         PIOA->PIO_PDR = PIO_PA13;
         PIOA->PIO_ABSR &= ~PIO_PA13;
 
-        /// Enable the clock to USART1.
+        ///> Enable the clock to USART1.
         PMC->PMC_PCER0 = (0x01 << ID_USART1);
     } else {
         hardwareUSART = USART3;
 
-        /// Disable PIO control on PD4, PD5 and set up for peripheral B (setting a high bit).
-        /// Section 31.7.24 - http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf
+        ///> Disable PIO control on PD4, PD5 and set up for peripheral B (setting a high bit).
+        ///> Section 31.7.24 - http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf
         PIOD->PIO_PDR = PIO_PD4;
         PIOD->PIO_ABSR |= PIO_PD4;
         PIOD->PIO_PDR = PIO_PD5;
         PIOD->PIO_ABSR |= PIO_PD5;
 
-        /// Enable the clock to USART3.
+        ///> Enable the clock to USART3.
         PMC->PMC_PCER0 = (0x01 << ID_USART3);
     }
 
-    // Disable the UART connection to make changes.
+    ///> Disable the UART connection to make changes.
     disable();
 
-    /// Set the baudrate to 115200. see page 799
-    /// Calculation: 5241600 / desired baudrate
-    /// 115200: 45
+    ///> Set the baudrate to 115200. see page 799
+    ///> Calculation: 5241600 / desired baudrate
+    ///> 115200: 45
     hardwareUSART->US_BRGR = (5241600u / baudrate);
 
-    /// No parity, normal channel mode. Use a 8 bit data field.
+    ///> No parity, normal channel mode. Use a 8 bit data field.
     hardwareUSART->US_MR = UART_MR_PAR_NO | UART_MR_CHMODE_NORMAL | US_MR_CHRL_8_BIT; // Might check if this definition is compatable with USART as well.
 
-    /// Disable the interrupt controller.
+    ///> Disable the interrupt controller.
     hardwareUSART->US_IDR = 0xFFFFFFFF;
 
-    /// Enable the UART controller
+    ///> Enable the UART controller
     enable();
 
-    /// USART Controller initialized
+    ///> USART Controller initialized
     USARTControllerInitialized = true;
 }
 
 unsigned int UARTConnection::available() {
     if (!USARTControllerInitialized) {
-        return false;
+        return 0;
     }
 
-    /// We use the USART Channel status register to check if there is data available in the receiver buffer.
-    //return (hardwareUSART->US_CSR & 1) != 0;
-
+    ///> We use the USART Channel status register to check if there is data available.
     if ((hardwareUSART->US_CSR & 1) != 0) {
-        //rxBuffer[rxBufferIndex++] = receiveByte();
         rxBuffer.push(receiveByte());
     }
 
     return rxBuffer.count();
 }
 
-bool UARTConnection::send(const char b) {
+bool UARTConnection::send(const uint8_t b) {
     if (!USARTControllerInitialized) {
         return false;
     }
 
     sendByte(b);
+
+    return true;
+}
+
+bool UARTConnection::send(const uint8_t* str) {
+    if (!USARTControllerInitialized) {
+        return false;
+    }
+
+    for (const uint8_t *p = str; *p != '\0'; p++) {
+        sendByte(*p);
+    }
 
     return true;
 }
@@ -113,7 +122,7 @@ bool UARTConnection::send(const char* str) {
     return true;
 }
 
-bool UARTConnection::send(const char* data, size_t length) {
+bool UARTConnection::send(const uint8_t* data, size_t length) {
     if (!USARTControllerInitialized) {
         return false;
     }
@@ -125,12 +134,10 @@ bool UARTConnection::send(const char* data, size_t length) {
     return true;
 }
 
-char UARTConnection::receive() {
+uint8_t UARTConnection::receive() {
     if (!USARTControllerInitialized || !rxBuffer.count()) {
-        return -1;
+        return 0;
     }
-
-    //return receiveByte();
 
     return rxBuffer.pop();   
 }
@@ -139,11 +146,11 @@ void UARTConnection::operator<<(const char *str) {
     send(str);
 }
 
-void UARTConnection::operator<<(const char c) {
+void UARTConnection::operator<<(const uint8_t c) {
     send(c);
 }
 
-void UARTConnection::operator>>(char &c) {
+void UARTConnection::operator>>(uint8_t &c) {
     c = receive();
 }
 
@@ -151,29 +158,29 @@ bool UARTConnection::isInitialized() {
     return USARTControllerInitialized;
 }
 
-void UARTConnection::sendByte(const char &b) {
-    /// Wait before we can send any more data
+void UARTConnection::sendByte(const uint8_t &b) {
+    ///> Wait before we can send any more data
     while (!txReady());
 
-    /// Send it!
+    ///> Send it!
     hardwareUSART->US_THR = b;
 }
 
-inline char UARTConnection::receiveByte() {
+inline uint8_t UARTConnection::receiveByte() {
     return hardwareUSART->US_RHR;
 }
 
 inline bool UARTConnection::txReady() {
-    /// We use the USART Channel status register to wait until the TXRDY bit is cleared.
+    ///> We use the USART Channel status register to wait until the TXRDY bit is cleared.
     return (hardwareUSART->US_CSR & 2);
 }
 
 inline void UARTConnection::enable() {
-    /// Enable the transmitter and receiver
+    ///> Enable the transmitter and receiver
     hardwareUSART->US_CR = UART_CR_RXEN | UART_CR_TXEN;
 }
 
 inline void UARTConnection::disable() {
-    /// Set the control register to reset and disable the receiver and transmitter.
+    ///> Set the control register to reset and disable the receiver and transmitter.
     hardwareUSART->US_CR = UART_CR_RSTRX | UART_CR_RSTTX | UART_CR_RXDIS | UART_CR_TXDIS;
 }

--- a/src/uart_connection.cpp
+++ b/src/uart_connection.cpp
@@ -7,71 +7,71 @@ UARTConnection::UARTConnection(unsigned int baudrate, UARTController controller,
 }
 
 UARTConnection::~UARTConnection() {
-    ///> Disable the UART controller on destruction
+    ///< Disable the UART controller on destruction
     disable();
 }
 
 void UARTConnection::begin() {
-    ///> Only initialize the UART controller if it hasn't been enabled.
+    ///< Only initialize the UART controller if it hasn't been enabled.
     if (USARTControllerInitialized) {
         return;
     }
 
-    ///> Setup the correct USART controller.
+    ///< Setup the correct USART controller.
     if (controller == UARTController::ONE) {
         hardwareUSART = USART0;
 
-        ///> Disable PIO control on PA10, PA11 and set up for peripheral A.
+        ///< Disable PIO control on PA10, PA11 and set up for peripheral A.
         PIOA->PIO_PDR = PIO_PA10;
         PIOA->PIO_ABSR &= ~PIO_PA10;
         PIOA->PIO_PDR = PIO_PA11;
         PIOA->PIO_ABSR &= ~PIO_PA11;
 
-        ///> Enable the clock to USART0.
+        ///< Enable the clock to USART0.
         PMC->PMC_PCER0 = (0x01 << ID_USART0);
     } else if (controller == UARTController::TWO) {
         hardwareUSART = USART1;
 
-        ///> Disable PIO control on PA12, PA13 and set up for peripheral A.
+        ///< Disable PIO control on PA12, PA13 and set up for peripheral A.
         PIOA->PIO_PDR = PIO_PA12;
         PIOA->PIO_ABSR &= ~PIO_PA12;
         PIOA->PIO_PDR = PIO_PA13;
         PIOA->PIO_ABSR &= ~PIO_PA13;
 
-        ///> Enable the clock to USART1.
+        ///< Enable the clock to USART1.
         PMC->PMC_PCER0 = (0x01 << ID_USART1);
     } else {
         hardwareUSART = USART3;
 
-        ///> Disable PIO control on PD4, PD5 and set up for peripheral B (setting a high bit).
-        ///> Section 31.7.24 - http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf
+        ///< Disable PIO control on PD4, PD5 and set up for peripheral B (setting a high bit).
+        ///< Section 31.7.24 - http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf
         PIOD->PIO_PDR = PIO_PD4;
         PIOD->PIO_ABSR |= PIO_PD4;
         PIOD->PIO_PDR = PIO_PD5;
         PIOD->PIO_ABSR |= PIO_PD5;
 
-        ///> Enable the clock to USART3.
+        ///< Enable the clock to USART3.
         PMC->PMC_PCER0 = (0x01 << ID_USART3);
     }
 
-    ///> Disable the UART connection to make changes.
+    ///< Disable the UART connection to make changes.
     disable();
 
-    ///> Set the baudrate to 115200. see page 799
-    ///> Calculation: 5241600 / desired baudrate
-    ///> 115200: 45
+    ///< Set the baudrate to 115200. see page 799
+    ///< Calculation: 5241600 / desired baudrate
+    ///< 115200: 45
     hardwareUSART->US_BRGR = (5241600u / baudrate);
 
-    ///> No parity, normal channel mode. Use a 8 bit data field.
+    ///< No parity, normal channel mode. Use a 8 bit data field.
     hardwareUSART->US_MR = UART_MR_PAR_NO | UART_MR_CHMODE_NORMAL | US_MR_CHRL_8_BIT; // Might check if this definition is compatable with USART as well.
 
-    ///> Disable the interrupt controller.
+    ///< Disable the interrupt controller.
     hardwareUSART->US_IDR = 0xFFFFFFFF;
 
-    ///> Enable the UART controller
+    ///< Enable the UART controller
     enable();
 
-    ///> USART Controller initialized
+    ///< USART Controller initialized
     USARTControllerInitialized = true;
 }
 
@@ -80,7 +80,7 @@ unsigned int UARTConnection::available() {
         return 0;
     }
 
-    ///> We use the USART Channel status register to check if there is data available.
+    ///< We use the USART Channel status register to check if there is data available.
     if ((hardwareUSART->US_CSR & 1) != 0) {
         rxBuffer.push(receiveByte());
     }
@@ -159,10 +159,10 @@ bool UARTConnection::isInitialized() {
 }
 
 void UARTConnection::sendByte(const uint8_t &b) {
-    ///> Wait before we can send any more data
+    ///< Wait before we can send any more data
     while (!txReady());
 
-    ///> Send it!
+    ///< Send it!
     hardwareUSART->US_THR = b;
 }
 
@@ -171,16 +171,16 @@ inline uint8_t UARTConnection::receiveByte() {
 }
 
 inline bool UARTConnection::txReady() {
-    ///> We use the USART Channel status register to wait until the TXRDY bit is cleared.
+    ///< We use the USART Channel status register to wait until the TXRDY bit is cleared.
     return (hardwareUSART->US_CSR & 2);
 }
 
 inline void UARTConnection::enable() {
-    ///> Enable the transmitter and receiver
+    ///< Enable the transmitter and receiver
     hardwareUSART->US_CR = UART_CR_RXEN | UART_CR_TXEN;
 }
 
 inline void UARTConnection::disable() {
-    ///> Set the control register to reset and disable the receiver and transmitter.
+    ///< Set the control register to reset and disable the receiver and transmitter.
     hardwareUSART->US_CR = UART_CR_RSTRX | UART_CR_RSTTX | UART_CR_RXDIS | UART_CR_TXDIS;
 }

--- a/src/uart_connection.hpp
+++ b/src/uart_connection.hpp
@@ -77,7 +77,7 @@ public:
    * @return true Byte send.
    * @return false Byte has not been send, USART controller not initialized.
    */
-  bool send(const char c);
+  bool send(const uint8_t c);
 
   /**
    * @brief Send a string.
@@ -86,7 +86,19 @@ public:
    * @return true String send.
    * @return false String has not been send, USART controller not initialized.
    */
-  bool send(const char *str);
+  bool send(const uint8_t *str);
+
+  /**
+   * @brief Send a string.
+   * 
+   * As we cannot static cast a const char* pointer to a const char* pointer, we overload the send function.
+   * Using reinterpreter cast would be a unfavourable solution, as the side effects are unkwown.
+   * 
+   * @param data String.
+   * @return true String has been send.
+   * @return false String has not been send, USART controller not initialized.
+   */
+  bool send(const char *data);
 
   /**
    * @brief Send a array of bytes with a specified length.
@@ -96,16 +108,16 @@ public:
    * @return true Array of bytes send.
    * @return false Array of bytes has not been send, USART controller not initialized.
    */
-  bool send(const char* data, size_t length);
+  bool send(const uint8_t* data, size_t length);
 
   /**
    * @brief Receive a single byte.
    * 
    * By popping the first element of the receive buffer, we return a received byte in a FIFO manner.
    * 
-   * @return char Received byte.
+   * @return uint8_t Received byte.
    */
-  char receive();
+  uint8_t receive();
 
   /**
    * @brief Checks if the internal USART controller has been initialized.
@@ -120,10 +132,13 @@ public:
    * 
    * @param c Byte.
    */
-  void operator<<(const char c);
+  void operator<<(const uint8_t c);
 
   /**
    * @brief Send a string.
+   * 
+   * As we want to easily send strings using the shifting operator, we need to declare a operator<<(const char* ).
+   * The use of a operator<<(const uint8_t* ) would be favourable, but unfortunately not possible.
    * 
    * @param str String (must be null terminated).
    */
@@ -134,7 +149,7 @@ public:
    * 
    * @param c Byte.
    */
-  void operator>>(char &c);
+  void operator>>(uint8_t &c);
 
   /**
    * @brief Destroy the UARTConnection object.
@@ -167,13 +182,13 @@ private:
    * @brief Holds the initialization status of the USART controller.
    * 
    */
-  bool USARTControllerInitialized = false;
+  bool USARTControllerInitialized;
 
   /**
    * @brief UART receive buffer.
    * 
    */
-  Queue<char, 250> rxBuffer;
+  Queue<uint8_t, 250> rxBuffer;
 
   /**
    * @brief Checks if the USART controller reports that the transmitter is ready to send.
@@ -188,14 +203,14 @@ private:
    *
    * @param char Byte to send.
    */
-  void sendByte(const char &b);
+  void sendByte(const uint8_t &b);
 
   /**
    * @brief Receive a single byte by reading the US_RHR register.
    * 
    * @return char 
    */
-  inline char receiveByte();
+  inline uint8_t receiveByte();
 };
 
 #endif


### PR DESCRIPTION
Using ```uint8_t``` instead of ```char```. As @CvXXX pointed out that the use of ```char``` causes undefined behaviour, I used ```uint8_t``` when possible (with the exception of the ```operator>>(const char*)``` for sending strings.