### PR TITLE
Hotfix: add namespaces

### DIFF
--- a/src/hardware_uart.cpp
+++ b/src/hardware_uart.cpp
@@ -1,5 +1,7 @@
 #include "hardware_uart.hpp"
 
+namespace UARTLib {
+
 HardwareUART::HardwareUART(unsigned int baudrate, UARTController controller, bool initializeController)
     : baudrate(baudrate), controller(controller), USARTControllerInitialized(false) {
     if (initializeController) {
@@ -191,4 +193,6 @@ inline void HardwareUART::enable() {
 inline void HardwareUART::disable() {
     ///< Set the control register to reset and disable the receiver and transmitter.
     hardwareUSART->US_CR = UART_CR_RSTRX | UART_CR_RSTTX | UART_CR_RXDIS | UART_CR_TXDIS;
+}
+
 }

--- a/src/hardware_uart.hpp
+++ b/src/hardware_uart.hpp
@@ -12,6 +12,8 @@
 #include "uart_connection.hpp"
 #include "wrap-hwlib.hpp"
 
+namespace UARTLib {
+
 /**
  * @brief Establishes an serial/UART connection using on of the three dedicated serial controllers located on the Arduino Due.
  *
@@ -206,5 +208,7 @@ class HardwareUART : public UARTConnection {
      */
     inline uint8_t receiveByte() override;
 };
+
+}
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,10 +4,10 @@
 
 class ExampleUARTUser {
   private:
-    UARTConnection &conn;
+    UARTLib::UARTConnection &conn;
 
   public:
-    ExampleUARTUser(UARTConnection &conn) : conn(conn){};
+    ExampleUARTUser(UARTLib::UARTConnection &conn) : conn(conn){};
 
     unsigned int bytesAvailable() {
         return conn.available();
@@ -35,9 +35,9 @@ int main() {
     hwlib::wait_ms(500);
 
     ///< Initialize a hardware UART connection, with a baudrate of 115200 and using RX1 and TX1 on the Arduino Due.
-    HardwareUART connHw(115200, UARTController::ONE);
+    UARTLib::HardwareUART connHw(115200, UARTLib::UARTController::ONE);
     ///< Initiailze a mock/fake UART connection. Use this one in your tests.
-    MockUART connMock(115200, UARTController::ONE);
+    UARTLib::MockUART connMock(115200, UARTLib::UARTController::ONE);
 
     ///< Create two dummy objects.
     ExampleUARTUser uartHwUser(connHw);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-//#include "hardware_uart.hpp"
-//#include "mock_uart.hpp"
 #include "uart_lib.hpp"
 #include "wrap-hwlib.hpp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
-#include "hardware_uart.hpp"
-#include "mock_uart.hpp"
+//#include "hardware_uart.hpp"
+//#include "mock_uart.hpp"
+#include "uart_lib.hpp"
 #include "wrap-hwlib.hpp"
 
 class ExampleUARTUser {

--- a/src/mock_uart.cpp
+++ b/src/mock_uart.cpp
@@ -1,5 +1,7 @@
 #include "mock_uart.hpp"
 
+namespace UARTLib {
+
 MockUART::MockUART(unsigned int baudrate, UARTController controller, bool initializeController)
     : baudrate(baudrate), controller(controller), USARTControllerInitialized(false) {
     if (initializeController) {
@@ -137,4 +139,6 @@ inline void MockUART::enable() {
 
 inline void MockUART::disable() {
     ///< Normally, we would disable the USART controller right now. Since it's a mock implementation, we don't do that.
+}
+
 }

--- a/src/mock_uart.hpp
+++ b/src/mock_uart.hpp
@@ -11,6 +11,8 @@
 
 #include "uart_connection.hpp"
 
+namespace UARTLib {
+
 /**
  * @brief In the mock implementation of UART communication, we only provide the user a testable interface,
  * as we don't have access to hardware registers.
@@ -200,5 +202,7 @@ class MockUART : public UARTConnection {
      */
     inline uint8_t receiveByte();
 };
+
+}
 
 #endif

--- a/src/uart_connection.hpp
+++ b/src/uart_connection.hpp
@@ -11,6 +11,8 @@
 #include "queue.hpp"
 #include "wrap-hwlib.hpp"
 
+namespace UARTLib {
+
 /**
  * @brief Used to select the UART controllers available on the Arduino Due.
  *
@@ -144,5 +146,7 @@ class UARTConnection : public hwlib::ostream, public hwlib::istream {
      */
     virtual inline uint8_t receiveByte() = 0;
 };
+
+}
 
 #endif

--- a/src/uart_lib.hpp
+++ b/src/uart_lib.hpp
@@ -4,11 +4,11 @@
 #ifdef BMPTK_TARGET_arduino_due
 
 ///< Include dependencies
-#include "uart_connection.hpp"
 #include "hardware_uart.hpp"
 
 #endif
 
+#include "uart_connection.hpp"
 #include "mock_uart.hpp"
 
 #endif

--- a/src/uart_lib.hpp
+++ b/src/uart_lib.hpp
@@ -1,0 +1,14 @@
+#ifndef UART_LIB
+#define UART_LIB
+
+#ifdef BMPTK_TARGET_arduino_due
+
+///< Include dependencies
+#include "uart_connection.hpp"
+#include "hardware_uart.hpp"
+
+#endif
+
+#include "mock_uart.hpp"
+
+#endif

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,6 +1,5 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
 #include "catch.hpp"
-//#include "../src/mock_uart.hpp"
 #include "uart_lib.hpp"
 
 TEST_CASE("Construct MockUART instance") {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -3,7 +3,7 @@
 #include "../src/mock_uart.hpp"
 
 TEST_CASE("Construct MockUART instance") {
-    MockUART uart(115200, UARTController::THREE, false);
+    UARTLib::MockUART uart(115200, UARTLib::UARTController::THREE, false);
 
     REQUIRE(!uart.isInitialized());
     REQUIRE(uart.available() == 0);

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
 #include "catch.hpp"
-#include "../src/mock_uart.hpp"
+//#include "../src/mock_uart.hpp"
+#include "uart_lib.hpp"
 
 TEST_CASE("Construct MockUART instance") {
     UARTLib::MockUART uart(115200, UARTLib::UARTController::THREE, false);


### PR DESCRIPTION
Moved classes into ```UARTLib``` namespace. Made ```uart_lib.hpp``` file for instantly loading UART dependencies.