### PR TITLE
Added docs to uart_connection.hpp and ran clang_format

### DIFF
--- a/src/hardware_uart.cpp
+++ b/src/hardware_uart.cpp
@@ -195,4 +195,4 @@ inline void HardwareUART::disable() {
     hardwareUSART->US_CR = UART_CR_RSTRX | UART_CR_RSTTX | UART_CR_RXDIS | UART_CR_TXDIS;
 }
 
-}
+} // namespace UARTLib

--- a/src/hardware_uart.hpp
+++ b/src/hardware_uart.hpp
@@ -209,6 +209,6 @@ class HardwareUART : public UARTConnection {
     inline uint8_t receiveByte() override;
 };
 
-}
+} // namespace UARTLib
 
 #endif

--- a/src/mock_uart.cpp
+++ b/src/mock_uart.cpp
@@ -141,4 +141,4 @@ inline void MockUART::disable() {
     ///< Normally, we would disable the USART controller right now. Since it's a mock implementation, we don't do that.
 }
 
-}
+} // namespace UARTLib

--- a/src/mock_uart.hpp
+++ b/src/mock_uart.hpp
@@ -203,6 +203,6 @@ class MockUART : public UARTConnection {
     inline uint8_t receiveByte();
 };
 
-}
+} // namespace UARTLib
 
 #endif

--- a/src/uart_connection.hpp
+++ b/src/uart_connection.hpp
@@ -117,10 +117,32 @@ class UARTConnection : public hwlib::ostream, public hwlib::istream {
      */
     virtual bool isInitialized() = 0;
 
+    /**
+     * @brief Write a character using UART.
+     *
+     * Used for interface inheriting between hwlib::istream and hwlib::ostream.
+     *
+     * @param c Character to send.
+     */
     virtual void putc(char c) = 0;
 
+    /**
+     * @brief Check if a character is available to read.
+     *
+     * Used for interface inheriting between hwlib::istream and hwlib::ostream.
+     *
+     * @return true
+     * @return false
+     */
     virtual bool char_available() = 0;
 
+    /**
+     * @brief Read a character using UART.
+     *
+     * Used for interface inheriting between hwlib::istream and hwlib::ostream.
+     *
+     * @return char
+     */
     virtual char getc() = 0;
 
   private:
@@ -147,6 +169,6 @@ class UARTConnection : public hwlib::ostream, public hwlib::istream {
     virtual inline uint8_t receiveByte() = 0;
 };
 
-}
+} // namespace UARTLib
 
 #endif

--- a/src/uart_lib.hpp
+++ b/src/uart_lib.hpp
@@ -8,7 +8,7 @@
 
 #endif
 
-#include "uart_connection.hpp"
 #include "mock_uart.hpp"
+#include "uart_connection.hpp"
 
 #endif


### PR DESCRIPTION
As the previous [PR to master](https://github.com/R2D2-2018/UART_LIB/pull/5) did not include documentation within the ```uart_connection.hpp``` file, i've added it.

